### PR TITLE
Fix `termstyle.auto()` with bpython and other "interpreters"

### DIFF
--- a/termstyle/termstyle.py
+++ b/termstyle/termstyle.py
@@ -65,7 +65,10 @@ class Style(object):
 
 def auto():
 	"""set colouring on if STDOUT is a terminal device, off otherwise"""
-	Style.enabled = sys.stdout.isatty()
+	if hasattr(sys.stdout, 'isatty') and sys.stdout.isatty():
+		Style.enabled = True
+	else:
+		Style.enabled = False
 
 def enable():
 	"""force coloured output"""


### PR DESCRIPTION
This is a just a quick fix to stop people filing bug reports to me when they're using bpython and other nastiness ;)

`bpython` overrides `sys.stdout` but provides no `isatty()` method.  I remember responding to a [similar problem with sphinx](http://www.mail-archive.com/sphinx-dev@googlegroups.com/msg01744.html), so it probably happens enough that such a cheap fix in `termstyle` is worth it.

Thanks,

James
