### PR TITLE
Added LICENSE to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include test*
+include LICENSE


### PR DESCRIPTION
For the [conda-forge build](https://github.com/conda-forge/staged-recipes/pull/1424#discussion_r76908545), we'd like to include a hard-link to the license. Doing so requires that the LICENSE be include in MANIFEST.in. If you could include this patch and then push a new source distribution to pypi that would be amazing.
